### PR TITLE
Check `exc_spec_dir` before `Dir.glob`

### DIFF
--- a/bin/rspec-kickstarter
+++ b/bin/rspec-kickstarter
@@ -80,7 +80,7 @@ end
 generator = RSpecKickstarter::Generator.new(spec_dir, delta_template, full_template)
 
 files = Dir.glob(dir_or_file)
-files -= Dir.glob(exc_spec_dir)
+files -= Dir.glob(exc_spec_dir) if exc_spec_dir
 
 files.each do |file_path|
   generator.write_spec(file_path, force_write, dry_run, rails_mode)


### PR DESCRIPTION
Fix 
```
TypeError: no implicit conversion of nil into String
bin/rspec-kickstarter:83:in `glob'
```