### PR TITLE
Update author/repo info

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,5 +269,5 @@ Copyright (c) 2018 - Tim Chambers
 
 MIT License
 
-https://github.com/tjchambers/rspec-jumpstart/blob/master/LICENSE.txt
+https://github.com/hintmedia/rspec-jumpstart/blob/master/LICENSE.txt
 

--- a/rspec-jumpstart.gemspec
+++ b/rspec-jumpstart.gemspec
@@ -8,11 +8,11 @@ Gem::Specification.new do |gem|
   gem.name          = 'rspec-jumpstart'
   gem.version       = RSpecJumpstart::VERSION
   gem.authors       = ['Timothy Chambers']
-  gem.email         = ['tim@possibilogy.com']
+  gem.email         = ['tim@hint.io']
   gem.licenses      = ['MIT']
   gem.description   = 'rspec-jumpstart supports you writing tests for existing code.'
   gem.summary       = 'rspec-jumpstart supports you writing tests for existing code.'
-  gem.homepage      = 'https://github.com/tjchambers/rspec-jumpstart'
+  gem.homepage      = 'https://github.com/hintmedia/rspec-jumpstart'
   gem.files         = Dir['{bin,lib}/**/*']
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Update gem spec and readme to point to hint repo so Rubygems points to the right place.

The CI and CodeClimate badges still point to Tim-specific locations. Not sure if they are safe to just `%s/tjchambers/hintmedia/` or not.